### PR TITLE
Minor: Changing the packaging scheme to jar

### DIFF
--- a/chatbot/pom.xml
+++ b/chatbot/pom.xml
@@ -3,7 +3,7 @@
    <modelVersion>4.0.0</modelVersion>
    <groupId>org.dice-research.sask</groupId>
    <artifactId>chatbot</artifactId>
-   <packaging>war</packaging>
+   <packaging>jar</packaging>
    <version>0.0.1-SNAPSHOT</version>
    <name>chatbot</name>
    <parent>


### PR DESCRIPTION
Changing the packaging scheme to jar to comply with the packaging scheme of other microservices.

Note: This doesn't have any impact on the functionality

Output indicating the difference:
HW15404:sask gsavandaiah$ grep -rin "<packaging>" .
./webclient/pom.xml:9:	<packaging>jar</packaging>
./discoveryclient/pom.xml:8:	<packaging>jar</packaging>
./eureka-server/pom.xml:8:	<packaging>jar</packaging>
./chatbot/pom.xml:6:   <packaging>war</packaging>
./pom.xml:8:	<packaging>pom</packaging>
./dbpedia-ms/pom.xml:8:	<packaging>jar</packaging>