### PR TITLE
BugFix: Call to load resources was missed out

### DIFF
--- a/chatbot/src/main/java/chatbot/core/handlers/rivescript/RiveScriptOutputAnalyzer.java
+++ b/chatbot/src/main/java/chatbot/core/handlers/rivescript/RiveScriptOutputAnalyzer.java
@@ -70,6 +70,7 @@ public class RiveScriptOutputAnalyzer {
 
 	// Custom Function to check if Query is found in Rive Script.
 	public static boolean isQueryFound(String query) {
+		resourceLoader();
 		String reply = bot.reply("user", query);
 		if ("NOT FOUND".equals(reply)) {
 			return false;


### PR DESCRIPTION
isQueryFound() funtion is called first to determine if the Rivescripts have a solution or not. But since the resources were not loaded the response was always null.